### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+pdudaemon (0.0.7-3) UNRELEASED; urgency=medium
+
+  * Apply multi-arch hints.
+    + pdudaemon-client: Add Multi-Arch: foreign.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 27 Oct 2020 07:27:06 -0000
+
 pdudaemon (0.0.7-2) unstable; urgency=medium
 
   * Add conflict on lavapdu-client which contains the same binary

--- a/debian/control
+++ b/debian/control
@@ -39,6 +39,7 @@ Package: pdudaemon-client
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}
 Conflicts: lavapdu-client
+Multi-Arch: foreign
 Description: client for pdudaemon
  Pdudaemon provides a standard way of controlling power controllers,
  which can either be local devices or networked PDUs. On top of that it ensures


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* pdudaemon-client: Add Multi-Arch: foreign. This fixes: pdudaemon-client could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/multiarch-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/pdudaemon/4c6572c0-3c74-458c-b69d-7706aeae8605.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)

No differences were encountered between the control files of package \*\*pdudaemon\*\*
### Control files of package pdudaemon-client: lines which differ (wdiff format)
* {+Multi-Arch: foreign+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/4c6572c0-3c74-458c-b69d-7706aeae8605/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/4c6572c0-3c74-458c-b69d-7706aeae8605/diffoscope)).
