### PR TITLE
Packaging fixes

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,9 @@ Vcs-Browser: https://github.com/pdudaemon/pkg-pdudaemon
 Package: pdudaemon
 Architecture: all
 Depends: ${misc:Depends},
-         ${python3:Depends}
+         ${python3:Depends},
+         python3-aiohttp,
+         python3-pymodbus,
 Recommends: telnet, openssh-client
 Description: daemon for controlling PDUs
  Pdudaemon provides a standard way of controlling power controllers,

--- a/debian/pydist-overrides
+++ b/debian/pydist-overrides
@@ -1,4 +1,0 @@
-daemon python-daemon; PEP386
-lockfile python-lockfile; PEP386
-pexpect python-pexpect; PEP386
-psycopg2 python-psycopg2; PEP386

--- a/debian/rules
+++ b/debian/rules
@@ -9,9 +9,6 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
-# Prevent setuptools/distribute from accessing the internet.
-export http_proxy = http://127.0.9.1:9
-
 DB2MAN = /usr/share/sgml/docbook/stylesheet/xsl/docbook-xsl/manpages/docbook.xsl
 XP     = xsltproc -''-nonet -''-param man.charmap.use.subset "0"
 

--- a/debian/rules
+++ b/debian/rules
@@ -23,8 +23,8 @@ export PYBUILD_INSTALL_ARGS=--install-script /usr/sbin
 %:
 	dh $@ --with python3 --buildsystem pybuild
 
-override_dh_instalsystemd:
-	dh_install_systemd -ppdudaemon --name=pdudaemon --no-restart-on-upgrade share/pdudaemon.service
+override_dh_installsystemd:
+	dh_installsystemd -ppdudaemon --name=pdudaemon --no-restart-on-upgrade pdudaemon.service
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
This is mainly to add missing runtime dependencies, see #[1055220](https://bugs.debian.org/1055220).
 aiohttp and pymodbus are not in setup.py, but only in requirements.txt, so pybuild cannot detect them.

I’m not sure the systemd override is necessary, but I have fixed it nevertheless.